### PR TITLE
Only push image to ECR on tagged release

### DIFF
--- a/.github/workflows/container-image.yaml
+++ b/.github/workflows/container-image.yaml
@@ -1,6 +1,10 @@
 name: Container Images
 
-on: push
+on:
+  push:
+    # Sequence of patterns matched against refs/tags
+    tags:
+      - "v*" # Push events to matching v*, i.e. v1.0, v20.15.10
 env:
   REGION : "us-east-1"
 jobs:


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
bug fix
**What is this PR about? / Why do we need it?**
stopping container image from trying to deploy every time (in turn failing test requirement) as seen here: https://github.com/kubernetes-sigs/aws-file-cache-csi-driver/pull/14
**What testing is done?** 

